### PR TITLE
Fix cross-platform md5 usage

### DIFF
--- a/md5_delete.sh
+++ b/md5_delete.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -euo pipefail
 
+# Determine available MD5 command (GNU coreutils `md5sum` or macOS `md5`).
+if command -v md5sum >/dev/null 2>&1; then
+  md5_cmd='md5sum'
+elif command -v md5 >/dev/null 2>&1; then
+  md5_cmd='md5 -r'
+else
+  echo "Error: neither 'md5sum' nor 'md5' command is available." >&2
+  exit 1
+fi
+
 # Usage check: Ensure exactly one argument (directory) is provided.
 if [ "$#" -ne 1 ]; then
   echo "Usage: $0 /path/to/directory"
@@ -20,7 +30,7 @@ while IFS= read -r -d '' file; do
   # Make sure it's a regular file (could be redundant with find's -type f).
   if [ -f "$file" ]; then
     # Calculate the MD5 checksum using awk for clarity.
-    file_checksum=$(md5sum "$file" | awk '{print $1}')
+    file_checksum=$($md5_cmd "$file" | awk '{print $1}')
     # If the checksum is already in the array, delete the duplicate.
     if [[ -n "${checksums[$file_checksum]:-}" ]]; then
       echo "Deleting duplicate file: $file"


### PR DESCRIPTION
## Summary
- detect whether `md5sum` or `md5` is available
- use the detected command when computing file hashes
- mark `md5_delete.sh` as executable

## Testing
- `bash -n md5_delete.sh`
- `./md5_delete.sh /tmp/testdata`

------
https://chatgpt.com/codex/tasks/task_e_6840d70b68e48321b4d2bce8f2681514